### PR TITLE
fix: add tmpfs /transcode mount to Plex for transcoding support

### DIFF
--- a/multimedia/compose.yml
+++ b/multimedia/compose.yml
@@ -103,6 +103,8 @@ services:
       - PLEX_CLAIM=${PLEX_CLAIM}
     devices:
       - /dev/dri:/dev/dri  # For hardware transcoding
+    tmpfs:
+      - /transcode  # RAM-based temp storage for transcoding
     volumes:
       - ${PLEX_CONFIG_PATH}:/config
       - ${TV_SHOWS_LOCATION}:/data/tv


### PR DESCRIPTION
Without a dedicated transcode directory, Plex writes temporary
transcoding files to the container's overlay filesystem, which can
fill up and cause transcoding to fail. Using tmpfs provides fast
RAM-based storage that is automatically cleaned up.

https://claude.ai/code/session_01XHkWwNHrNdC8jDVMYZAWxb