### PR TITLE
fix(matter): increase memory limit to 512M and add healthcheck

### DIFF
--- a/home-assistant/compose.yml
+++ b/home-assistant/compose.yml
@@ -8,7 +8,7 @@ services:
       mosquitto:
         condition: service_healthy
       matter-server:
-        condition: service_started
+        condition: service_healthy
     volumes:
       - /opt/docker/home-assistant/config:/config
       - /etc/localtime:/etc/localtime:ro
@@ -91,7 +91,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 256M
+          memory: 512M
     logging:
       driver: json-file
       options:
@@ -104,9 +104,16 @@ services:
       - /opt/docker/home-assistant/matter-server/data:/data/
       - /run/dbus:/run/dbus:ro
 
+    healthcheck:
+      test: ["CMD-SHELL", "printf 'GET / HTTP/1.1\\r\\nHost: localhost\\r\\n\\r\\n' | nc -w 5 localhost 5580 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
     # Required for mDNS to work correctly
     network_mode: host
-    
+
     # Accessible at http://192.168.0.237:5580/
 
 networks:


### PR DESCRIPTION
## Résumé technique

### Contexte
Le Matter Server tournait à 85.6% de sa mémoire (219/256 MiB) provoquant des subscription liveness timeouts systémiques sur l'ensemble des 14+ nodes Matter. Ceci explique les périodes offline intermittentes dans Home Assistant alors que l'app eWeLink (protocole cloud sans sessions CASE) contrôle les mêmes appareils sans problème.

L'absence de healthcheck sur le matter-server signifiait qu'un crash silencieux ou un état dégradé n'était pas détecté par Docker — tous les devices Matter tombaient offline sans mécanisme de recovery automatique.

### Approche retenue
Augmenter la mémoire du Matter Server pour donner de l'espace au CHIP SDK (sessions CASE, cache mDNS, tables de souscription) et ajouter un healthcheck pour détecter les crashes silencieux. Alternative rejetée : basculer immédiatement sur MQTT/Tasmota — trop invasif comme première action, à considérer si le problème persiste après 48h d'observation.

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `home-assistant/compose.yml` | Memory limit 256M → 512M | Le CHIP SDK à 85.6% provoque l'éviction de session state et les timeout de souscription |
| `home-assistant/compose.yml` | Ajout healthcheck sur port 5580 (WebSocket) | Détection de crash silencieux du Matter Server |
| `home-assistant/compose.yml` | Dépendance HA `service_started` → `service_healthy` | HA ne démarre que si Matter Server est opérationnel |

### Points d'attention pour la revue
- Le healthcheck utilise `nc` (netcat) sur le port WebSocket 5580 — vérifier que `nc` est disponible dans l'image `python-matter-server`
- Si `nc` n'est pas disponible, alternative : `test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:5580')\" || exit 1"]`
- Le `start_period: 30s` donne au Matter Server le temps d'initialiser ses sessions CASE au démarrage
- Après déploiement, monitorer `docker stats matter-server` pendant 48h — la mémoire devrait se stabiliser sous 60% (300 MiB)

### Tests
- Pas de suite de tests automatisés (repository de configuration Docker uniquement)
- Validation manuelle requise : `docker compose up -d` puis observation des logs Matter Server

### Prochaines étapes
- [ ] Vérifier la disponibilité de `nc` dans l'image matter-server (sinon adapter le healthcheck)
- [ ] Déployer et redémarrer le matter-server
- [ ] Monitorer les subscription timeouts pendant 48h (baseline actuelle : ~295/jour)
- [ ] Si les SONOFF MINI-D continuent de flancher après 48h → envisager eWeLink LAN integration ou flash ESPHome/Tasmota

---
_Implémentation générée automatiquement par IA_